### PR TITLE
added additional env line

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ NGINX_HOSTNAME=externally_accessible_hostname
 NGINX_PORT='443'
 NGINX_SSL_CERTFILE='certfile_development.pem'
 NGINX_SSL_KEYFILE='keyfile_development.pem'
+NGINX_SSL_PATH='./webserver/ssl'


### PR DESCRIPTION
I've added one additional environmental line for 'NGINX_SSL_PATH' to .env.example
'docker compose pull' was not able to perform until this was added.